### PR TITLE
Re-Arrange nginx-ssl.sh parameters.

### DIFF
--- a/scripts/install/nginx/nginx-ssl.sh
+++ b/scripts/install/nginx/nginx-ssl.sh
@@ -29,7 +29,7 @@ fi
 # Ignore browser errors related to certificate validity.
 
 # Create Self-Signed SSL Certificate
-openssl req -new -newkey -x509 rsa:4096 -sha256 -days 36500 -nodes \
+openssl req -new -newkey rsa:4096 -sha256 -days 36500 -nodes -x509 \
 -keyout /etc/nginx/ssl/localhost/localhost.key -out /etc/nginx/ssl/localhost/localhost.crt \
 -subj "/C=US/ST=Florida/L=Orlando/O=EngineScript/CN=localhost" \
 -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"


### PR DESCRIPTION
Re-Arrange openssl parameters, so it will generate certificate properly. Otherwise it will give following message:

`req: Use -help for summary.`