### PR TITLE
Fix for Useless conditional

### DIFF
--- a/config/var/www/admin/control-panel/external-services/external-services.js
+++ b/config/var/www/admin/control-panel/external-services/external-services.js
@@ -1505,9 +1505,7 @@ export class ExternalServicesManager {
       console.warn('Corrupted service preferences detected; resetting stored preferences to defaults.');
       // Clear invalid entry
       try {
-        if (storage) {
-          storage.removeItem('servicePreferences');
-        }
+        storage.removeItem('servicePreferences');
       } catch (removeError) {
         console.error('Failed to clear invalid stored preferences:', removeError);
       }


### PR DESCRIPTION
To fix this without changing behavior, remove the redundant truthiness check around `storage.removeItem('servicePreferences')` in the parse-error cleanup block. At that point in control flow, `storage` is already guaranteed to exist (otherwise the function would have returned earlier), so directly calling `storage.removeItem(...)` inside the existing `try/catch` preserves error handling while eliminating the always-true condition.

Change region: `config/var/www/admin/control-panel/external-services/external-services.js`, around lines 1507–1510 in `loadServicePreferences()`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._