### PR TITLE
Fix for Useless conditional

### DIFF
--- a/config/var/www/admin/control-panel/external-services/external-services.js
+++ b/config/var/www/admin/control-panel/external-services/external-services.js
@@ -1486,9 +1486,7 @@ export class ExternalServicesManager {
       if (storedPrefs.length > MAX_PREFERENCES_SIZE) {
         console.warn('Stored service preferences exceed allowed size; resetting to defaults.');
         try {
-          if (storage) {
-            storage.removeItem('servicePreferences');
-          }
+          storage.removeItem('servicePreferences');
         } catch (removeError) {
           console.error('Failed to clear oversized stored preferences:', removeError);
         }
@@ -1505,9 +1503,7 @@ export class ExternalServicesManager {
       console.warn('Corrupted service preferences detected; resetting stored preferences to defaults.');
       // Clear invalid entry
       try {
-        if (storage) {
-          storage.removeItem('servicePreferences');
-        }
+        storage.removeItem('servicePreferences');
       } catch (removeError) {
         console.error('Failed to clear invalid stored preferences:', removeError);
       }


### PR DESCRIPTION
To fix this, remove the redundant `if (storage)` guards in the two inner cleanup blocks and call `storage.removeItem('servicePreferences')` directly.  
This preserves functionality because execution can only reach those blocks after the earlier `if (!storage) return null;` guard.

**Where to change:**
- File: `config/var/www/admin/control-panel/external-services/external-services.js`
- Region: `loadServicePreferences()` around lines 1488–1511.
- No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._